### PR TITLE
Display results for git-clang-format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .vscode/
+.idea/
+*.iml

--- a/Jenkins/Phabricator-pipeline/Jenkinsfile
+++ b/Jenkins/Phabricator-pipeline/Jenkinsfile
@@ -23,11 +23,12 @@ pipeline {
             PHABRICATOR_HOST = 'https://reviews.llvm.org'
             PHAB_LOG = "${WORKSPACE}/build/.phabricator-comment"
             SCRIPT_DIR = "${WORKSPACE}/llvm-premerge-checks/scripts"
-            MY_BUILD_ID = "${JOB_BASE_NAME}-${BUILD_NUMBER}"
-            TARGET_DIR = "/mnt/nfs/results/${MY_BUILD_ID}"
-            RESULT_URL = "http://results.llvm-merge-guard.org/${MY_BUILD_ID}"
+            BUILD_ID = "${JOB_BASE_NAME}-${BUILD_NUMBER}"
+            TARGET_DIR = "/mnt/nfs/results/${BUILD_ID}"
+            RESULT_URL = "http://results.llvm-merge-guard.org/${BUILD_ID}"
             TEST_REPORT = "${WORKSPACE}/build/test-results.xml"
             DIFF_JSON = "${WORKSPACE}/build/diff.json"
+            TARGET_DIR="/mnt/nfs/results/${JOB_BASE_NAME}-${BUILD_NUMBER}"
     }
     stages {
         stage("build info"){
@@ -44,8 +45,10 @@ pipeline {
                 {
                     git url: 'https://github.com/google/llvm-premerge-checks.git'
                 }
+                sh 'rm -rf build || true'
                 sh 'mkdir -p build'
-            }            
+                sh 'mkdir -p "${TARGET_DIR}'
+            }
         }
         stage('arc patch'){
             steps {
@@ -67,6 +70,11 @@ pipeline {
                 sh "${SCRIPT_DIR}/run_ninja.sh check-all"
             }
         }
+        stage('linters') {
+            steps {
+                sh "${SCRIPT_DIR}/lint.sh"
+            }
+        }
     }
     post { 
         always { 
@@ -84,6 +92,7 @@ pipeline {
                 """
             }
             /// send results to Phabricator
+            // TODO: list all files from results directory instead
             sh """
 set +x
 cat <<-EOF>> ${PHAB_LOG}
@@ -96,7 +105,8 @@ EOF
                 --test-result-file "${TEST_REPORT}" \
                 --comment-file "${PHAB_LOG}" \
                 --host "${PHABRICATOR_HOST}/api/" \
-                --buildresult ${currentBuild.result}
+                --buildresult ${currentBuild.result} \
+                ---clang-format-patch="${TARGET_DIR}/clang-format.patch"
                 """
         }
     }    

--- a/Jenkins/master-linux-pipeline/Jenkinsfile
+++ b/Jenkins/master-linux-pipeline/Jenkinsfile
@@ -21,7 +21,6 @@ pipeline {
         BUILD_ID="${JOB_BASE_NAME}-${BUILD_NUMBER}"
         TARGET_DIR="/mnt/nfs/results/${BUILD_ID}"
         SCRIPT_DIR = "${WORKSPACE}/llvm-premerge-checks/scripts"
-
     }
     stages {
         stage("git checkout"){
@@ -29,6 +28,7 @@ pipeline {
                 git url: 'https://github.com/llvm/llvm-project.git'
                 sh 'git clean -fdx'
                 sh 'mkdir -p llvm-premerge-checks'
+                sh 'mkdir -p "${TARGET_DIR}"'
                 dir("llvm-premerge-checks")
                 {
                     git url: 'https://github.com/google/llvm-premerge-checks.git'

--- a/Jenkins/master-windows-pipeline/Jenkinsfile
+++ b/Jenkins/master-windows-pipeline/Jenkinsfile
@@ -21,7 +21,6 @@ pipeline {
         BUILD_ID="${JOB_BASE_NAME}-${BUILD_NUMBER}"
         TARGET_DIR="/mnt/nfs/results/${BUILD_ID}"
         SCRIPT_DIR = "${WORKSPACE}/llvm-premerge-checks/scripts"
-
     }
     stages {
         stage("git checkout"){

--- a/containers/build_run.sh
+++ b/containers/build_run.sh
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Starts a new instances of a docker image. Example:
+# sudo build_run.sh agent-debian-testing-clang8-ssd /bin/bash
+
 set -eux
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 

--- a/docs/playbooks.md
+++ b/docs/playbooks.md
@@ -108,5 +108,8 @@ Invoke-WebRequest -uri 'https://raw.githubusercontent.com/google/llvm-premerge-c
 
 ## Testing scripts locally
 
-To experiment with a build scripts locally you will need a Conduit token. You can create one at
-https://reviews.llvm.org/settings/user/<USERNAME>/page/apitokens/ .
+Build and run agent docker image `sudo build_run.sh agent-debian-testing-clang8-ssd /bin/bash`.
+
+Within a container set environment variables similar to [pipeline](https://github.com/google/llvm-premerge-checks/blob/master/Jenkins/Phabricator-pipeline/Jenkinsfile).
+
+Additionally set `WORKSPACE`, `PHID` and `DIFF_ID` parameters. Set `CONDUIT_TOKEN` with your personal one from `https://reviews.llvm.org/settings/user/<USERNAME>/page/apitokens/`.

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the the Apache License v2.0 with LLVM Exceptions (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Runs clang-format
+# Inputs: TARGET_DIR, WORKSPACE
+# Outputs: ${TARGET_DIR}/clang-format.patch (if there are clang-format findings).
+set -eux
+
+echo "Running linters... ====================================="
+
+cd "${WORKSPACE}"
+# Let clang format apply patches --diff doesn't produces results in the format
+# we want.
+python3 /usr/bin/git-clang-format-8 --style=llvm --binary=/usr/bin/clang-format-8
+set +e
+git diff -U0 --exit-code > "${TARGET_DIR}"/clang-format.patch
+STATUS="${PIPESTATUS[0]}"
+set -e
+# Drop file if there are no findings.
+if [[ $STATUS == 0 ]]; then rm "${TARGET_DIR}"/clang-format.patch; fi
+
+# Revert changes of git-clang-format.
+git checkout -- .
+
+echo "linters completed ======================================"

--- a/scripts/phabtalk/README.md
+++ b/scripts/phabtalk/README.md
@@ -1,2 +1,4 @@
-This folder contains Python scripts that to Phabricator.
+This folder contains Python scripts that talk to Phabricator.
+
 They require a few libraries listed in `requirements.txt`.
+To install the requirements locally run `pip3 install -r requirements.txt`.

--- a/scripts/run_ninja.sh
+++ b/scripts/run_ninja.sh
@@ -14,23 +14,22 @@
 # limitations under the License.
 set -eu
 
+# Runs ninja
+# Inputs: TARGET_DIR, WORKSPACE.
+# Outputs: $TARGET_DIR/test_results.xml
+
 CMD=$1
-echo "Running ${CMD}... ====================================="
-cd ${WORKSPACE}
-# TODO: move copy operation to pipeline
-BUILD_ID="${JOB_BASE_NAME}-${BUILD_NUMBER}"
-TARGET_DIR="/mnt/nfs/results/${BUILD_ID}"
+echo "Running ninja ${CMD}... ====================================="
 
 ulimit -n 8192
-cd build
+cd "${WORKSPACE}/build"
 
 set +e
 ninja ${CMD} 
 RETURN_CODE="$?"
 set -e
 
-echo "check-all completed ======================================"
-# TODO: move copy operation to pipeline
+echo "ninja ${CMD} completed ======================================"
 if test -f "test-results.xml" ; then
 	cp test-results.xml ${TARGET_DIR}
 fi


### PR DESCRIPTION
Attach diffs produced by git-clang-format as lint messages. For #21 

E.g.: https://reviews.llvm.org/D71197?id=233029
Will add a link to file and code to apply the patch in the next PR.

+ don't create TARGET_DIR in scripts;
+ updated section about local build;
+ partially specified inputs / outputs of scripts so it's more transparent what are the results;
+ added symlink to compile_command.json (clang-tidy will need it).