### PR TITLE
Update image to use default version

### DIFF
--- a/containers/agent-debian-testing-clang8-ssd/Dockerfile
+++ b/containers/agent-debian-testing-clang8-ssd/Dockerfile
@@ -2,14 +2,16 @@ FROM debian:testing
 
 RUN apt-get update ;\
     apt-get install -y --no-install-recommends locales \
-        cmake ninja-build git ca-certificates clang-8 lld-8 ccache python3 build-essential \
-        clang-tidy-8 clang-format-8 \
+        cmake ninja-build git ca-certificates clang lld ccache python3 build-essential \
+        clang-tidy clang-format \
         python3-psutil arcanist zip wget \
         openjdk-11-jdk \
         python3-pip python3-setuptools \
-        swig python3-dev libedit-dev libncurses5-dev libxml2-dev liblzma-dev golang rsync; \ 
+        swig python3-dev libedit-dev libncurses5-dev libxml2-dev liblzma-dev golang rsync jq; \
         apt-get clean
 
+# Make python3 default (needed by git-clang-format and others).
+RUN rm -f /usr/bin/python && ln -s /usr/bin/python3 /usr/bin/python
 # required for openssh server
 RUN mkdir -p /run/sshd
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -23,7 +23,7 @@ echo "Running linters... ====================================="
 cd "${WORKSPACE}"
 # Let clang format apply patches --diff doesn't produces results in the format
 # we want.
-python3 /usr/bin/git-clang-format-8 --style=llvm --binary=/usr/bin/clang-format-8
+git-clang-format --style=llvm
 set +e
 git diff -U0 --exit-code > "${TARGET_DIR}"/clang-format.patch
 STATUS="${PIPESTATUS[0]}"

--- a/scripts/run_cmake.sh
+++ b/scripts/run_cmake.sh
@@ -19,8 +19,8 @@ set -eux
 # Outputs: $TARGET_DIR/CMakeCache.txt, $WORKSPACE/compile_commands.json (symlink).
 
 echo "Running CMake... ======================================"
-export CC=clang-8
-export CXX=clang++-8
+export CC=clang
+export CXX=clang++
 export LD=LLD
 
 cd "$WORKSPACE"/build


### PR DESCRIPTION
+ add jq to parse conduit responses later

Run in local docker container and it seems to work fine.

for #76 