### PR TITLE
Run clang-tidy and parse message

### DIFF
--- a/Jenkins/Phabricator-pipeline/Jenkinsfile
+++ b/Jenkins/Phabricator-pipeline/Jenkinsfile
@@ -104,11 +104,13 @@ pipeline {
             }
             /// send results to Phabricator
             sh """${SCRIPT_DIR}/phabtalk/phabtalk.py "${PHID}" "${DIFF_ID}" \
+                --workspace "${WORKSPACE}" \
                 --conduit-token "${CONDUIT_TOKEN}" \
                 --test-result-file "test-results.xml" \
                 --host "${PHABRICATOR_HOST}/api/" \
                 --buildresult ${currentBuild.result} \
                 --clang-format-patch "clang-format.patch" \
+                --clang-tidy-result "clang-tidy.txt" \
                 --results-dir "${TARGET_DIR}" \
                 --results-url "${RESULT_URL}"
                 """

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -21,17 +21,15 @@ set -eux
 echo "Running linters... ====================================="
 
 cd "${WORKSPACE}"
-# Let clang format apply patches --diff doesn't produces results in the format
-# we want.
+# Let clang format apply patches --diff doesn't produces results in the format we want.
 git-clang-format --style=llvm
 set +e
 git diff -U0 --exit-code > "${TARGET_DIR}"/clang-format.patch
 STATUS="${PIPESTATUS[0]}"
 set -e
-# Drop file if there are no findings.
-if [[ $STATUS == 0 ]]; then rm "${TARGET_DIR}"/clang-format.patch; fi
-
 # Revert changes of git-clang-format.
 git checkout -- .
+
+git diff HEAD^ | clang-tidy-diff -p1 -quiet > "${TARGET_DIR}"/clang-tidy.txt
 
 echo "linters completed ======================================"


### PR DESCRIPTION
+ don't assume that clang-format has passed if there is no file.
  If linters didn't run at all file will be missing.
+ add "gray" icon for the result if it's unknown.
+ assume whole build is failed if clang-format or clang-tidy found something.
+ combine multiple lint messages per line.