### PR TITLE
   Update bot report

### DIFF
--- a/docs/clang_tidy.md
+++ b/docs/clang_tidy.md
@@ -1,0 +1,29 @@
+# clang-tidy checks
+## warning is not useful
+If you found that a warning produced by clang-tidy is not useful:
+  
+- If clang-tidy must not run for some files at all (e.g. lit test), please
+[add files to blacklist](scripts/clang-tidy.ignore).
+
+- Consider fixing or [suppressing diagnostic](https://clang.llvm.org/extra/clang-tidy/#suppressing-undesired-diagnostics)
+  if there is a good reason.
+  
+- [File a bug](issues/new?assignees=&labels=bug&template=bug_report.md&title=)
+  if build process should be improved. 
+
+- If you believe that you found a clang-tidy bug then please keep in mind that clang-tidy version run by bot
+  might not be most recent. Please reproduce your issue on current version before submitting a bug to clang-tidy.
+
+## Review comments
+
+Build bot leaves inline comments only for a small subset of files that are not blacklisted for analysis (see above) *and*
+specifically whitelisted for comments.
+
+That is done to avoid potential noise when a file already contains a number of warnings.
+
+If your are confident that some files are in good shape already, please
+[whitelist them](scripts/clang-tidy-comments.ignore).
+
+----
+
+[about pre-merge checks](docs/user_doc.md)

--- a/docs/user_doc.md
+++ b/docs/user_doc.md
@@ -44,16 +44,18 @@ Only then can the build server apply the patch locally and run the builds and te
 Once you're signed up, Phabricator will automatically trigger a build for every new patch you upload or every existing patch you modify. Phabricator shows the build results at the top of the entry:
 ![build status](images/diff_detail.png)
 
+Bot will compile and run tests, run clang-format and [clang-tidy](docs/clang_tidy.md) on lines changed. 
+
 If a unit test failed, this is shown below the build status. You can also expand the unit test to see the details:
 ![unit test results](images/unit_tests.png)
 
-After every build the build server will comment on your latest patch, so that you can also see the results for previous changes. The comment also contains a link to the log files:
+After every build the build server will comment on your latest patch, so that you can also see the results for previous changes.
+The comment also contains a link to the log files:
 ![bot comment](images/bot_comment.png)
 
 The build logs are stored for 90 days and automatically deleted after that.
 
 You can also trigger a build manually by using the "Run Plan Manually" link on the [Harbormaster page](https://reviews.llvm.org/harbormaster/plan/3/) and entering a revision ID in the pop-up window.
-
 
 # Reporting issues
 


### PR DESCRIPTION
- add links to join beta and report issue
- add link "not useful" to clang-tidy warning
- clang-tidy comment in report now tells how many inline comments were
  added