### PR TITLE
Add name of build agent to summary

### DIFF
--- a/Jenkins/Phabricator-pipeline/Jenkinsfile
+++ b/Jenkins/Phabricator-pipeline/Jenkinsfile
@@ -174,7 +174,8 @@ pipeline {
                 --clang-tidy-ignore "${SCRIPT_DIR}/clang-tidy-comments.ignore" \
                 --results-dir "${TARGET_DIR}" \
                 --results-url "${RESULT_URL}" \
-                --failures "${failure_message}"
+                --failures "${failure_message}" \
+                --name "linux"
                 """
         }
     }    

--- a/Jenkins/Phabricator-windows-pipeline/Jenkinsfile
+++ b/Jenkins/Phabricator-windows-pipeline/Jenkinsfile
@@ -162,7 +162,8 @@ pipeline {
                     --results-dir "${RESULT_DIR}" ^
                     --results-url "${RESULT_URL}" ^
                     --failures "${failure_message}" ^
-                    --buildresult ${currentBuild.result}
+                    --buildresult ${currentBuild.result} ^
+                    --name "windows"
                 """            
             dir("${RESULT_DIR}") {
                 // upload results to


### PR DESCRIPTION
Right now we have two "summary" reported. Adding a --name param to have "summary linux" and "summary windows" instead.