### PR TITLE
Add new deployment for agent that will do premerge checks

### DIFF
--- a/containers/agent-debian-testing-buildkite/Dockerfile
+++ b/containers/agent-debian-testing-buildkite/Dockerfile
@@ -45,9 +45,9 @@ ENV CCACHE_PATH=/mnt/disks/ssd0/ccache
 # configure locale
 RUN sed --in-place '/en_US.UTF-8/s/^#//' /etc/locale.gen ;\
     locale-gen
-ENV LANG en_US.UTF-8  
-ENV LANGUAGE en_US:en  
-ENV LC_ALL en_US.UTF-8  
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
 
 # buildkite
 RUN apt-get install -y apt-transport-https gnupg;\
@@ -55,8 +55,6 @@ RUN apt-get install -y apt-transport-https gnupg;\
     apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198 ;\
     apt-get update ;\
     apt-get install -y buildkite-agent
-
-VOLUME /credentials
 
 CMD ["/scripts/start_agent.sh"]
 

--- a/containers/agent-debian-testing-buildkite/start_agent.sh
+++ b/containers/agent-debian-testing-buildkite/start_agent.sh
@@ -28,5 +28,4 @@ chown -R ${USER}:${USER} "${CCACHE_PATH}"
 # TODO(kuhnel): wipe the disk(s) on startup
 
 # start the buildkite agent
-su buildkite-agent -c "buildkite-agent start --tags \"os=linux\" --build-path=/mnt/disks/ssd0/agent \
-    --token `cat /credentials/buildkite-token`"
+su buildkite-agent -c "buildkite-agent start --build-path=/mnt/disks/ssd0/agent"

--- a/kubernetes/buildkite/agents_premerge.yaml
+++ b/kubernetes/buildkite/agents_premerge.yaml
@@ -15,20 +15,18 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: agent-debian-testing-clang8-buildkite
+  name: agent-premerge-debian
   namespace: buildkite
 spec:
   replicas: 1
   template:
     metadata:
       labels:
-        app: agent-debian-testing-clang8-buildkite
+        app: agent-premerge-debian
     spec:
       containers:
       - name: agent-debian-testing-buildkite
         image: gcr.io/llvm-premerge-checks/agent-debian-testing-buildkite
-        ports:
-        - containerPort: 22
         resources:
           limits:
             cpu: 30
@@ -37,7 +35,7 @@ spec:
             cpu: 30
             memory: 45Gi
         volumeMounts:
-        - name: ssd 
+        - name: ssd
           mountPath: /mnt/disks/ssd0
         env:
         - name: BUILDKITE_AGENT_TOKEN
@@ -46,7 +44,7 @@ spec:
               name: agent-token
               key: token
         - name: BUILDKITE_AGENT_TAGS
-          value: "queue=release,os=linux"
+          value: "queue=premerge,os=linux"
       volumes:
       - name: ssd
         hostPath:


### PR DESCRIPTION
maybe we will later use same agents for everything but for now I don't
want to modify working build much. But I have updated deployment of
release agent to use correct docker image (there were renamed a while
ago) and pass tags and agent token via env variables.

Have not deployed new deployment for release yet.