### PR TITLE
build on buildkite

### DIFF
--- a/containers/buildkite-premerge-debian/Dockerfile
+++ b/containers/buildkite-premerge-debian/Dockerfile
@@ -7,8 +7,6 @@ RUN echo 'install buildkite' ;\
     apt-get update ;\
     apt-get install -y buildkite-agent; \
     apt-get clean;
-
 COPY *.sh /usr/local/bin/
 RUN chmod og+rx /usr/local/bin/*.sh
-ENV CCACHE_PATH=/mnt/disks/ssd0/ccache
 CMD ["start_agent.sh"]

--- a/containers/buildkite-premerge-debian/start_agent.sh
+++ b/containers/buildkite-premerge-debian/start_agent.sh
@@ -15,12 +15,12 @@
 
 # Buildkite installation creates 'buildkite-agent' user.
 USER=buildkite-agent
-SSD_ROOT="/mnt/disks/ssd0"
-AGENT_ROOT="${SSD_ROOT}/agent"
 
 # prepare work directory
-mkdir -p "${AGENT_ROOT}"
-chown -R ${USER}:${USER} "${AGENT_ROOT}"
+mkdir -p "${BUILDKITE_BUILD_PATH}"
+chown -R ${USER}:${USER} "${BUILDKITE_BUILD_PATH}"
+
+export CCACHE_PATH="${BUILDKITE_BUILD_PATH}"/ccache
 mkdir -p "${CCACHE_PATH}"
 chown -R ${USER}:${USER} "${CCACHE_PATH}"
 
@@ -31,4 +31,4 @@ chmod 700 /var/lib/buildkite-agent/.ssh
 chmod 600 /var/lib/buildkite-agent/.ssh/*
 chown -R $USER:$USER /var/lib/buildkite-agent/.ssh
 
-su buildkite-agent -c "buildkite-agent start --build-path=/mnt/disks/ssd0/agent"
+su buildkite-agent -c "buildkite-agent start"

--- a/kubernetes/buildkite/agents_premerge.yaml
+++ b/kubernetes/buildkite/agents_premerge.yaml
@@ -47,6 +47,8 @@ spec:
               key: token
         - name: BUILDKITE_AGENT_TAGS
           value: "queue=premerge,os=linux"
+        - name: BUILDKITE_BUILD_PATH
+          value: "/mnt/disks/ssd0/agent"
         - name: CONDUIT_TOKEN
           valueFrom:
             secretKeyRef:

--- a/phabricator-proxy/main.py
+++ b/phabricator-proxy/main.py
@@ -44,7 +44,7 @@ def build():
         headers = {'Authorization': f'Bearer {buildkite_api_token}'}
         response = requests.post(
             'https://api.buildkite.com/v2/organizations/llvm-project'
-            '/pipelines/premerge/builds',
+            '/pipelines/diff-checks/builds',
             json=build_request,
             headers=headers)
         app.logger.info('buildkite response: %s %s', response.status_code, response.text)

--- a/scripts/buildkite/apply_patch.sh
+++ b/scripts/buildkite/apply_patch.sh
@@ -1,5 +1,23 @@
 #!/usr/bin/env bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the the Apache License v2.0 with LLVM Exceptions (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Scripts that use secrets has to be a separate files, not inlined in pipeline:
+# https://buildkite.com/docs/pipelines/secrets#anti-pattern-referencing-secrets-in-your-pipeline-yaml
+
 scripts/phabtalk/apply_patch2.py $ph_buildable_diff \
+  --path "${BUILDKITE_BUILD_PATH}"/llvm-project \
   --token $CONDUIT_TOKEN \
   --url $PHABRICATOR_HOST \
   --comment-file apply_patch.txt \

--- a/scripts/buildkite/create_branch_pipeline.py
+++ b/scripts/buildkite/create_branch_pipeline.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# Copyright 2020 Google LLC
+#
+# Licensed under the the Apache License v2.0 with LLVM Exceptions (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import yaml
+
+if __name__ == '__main__':
+    queue = os.getenv("BUILDKITE_AGENT_META_DATA_QUEUE", "default")
+    diff_id = os.getenv("ph_buildable_diff")
+    steps = []
+    create_branch_step = {
+            'label': 'create branch',
+            'key': 'create-branch',
+            'commands': ['scripts/buildkite/apply_patch.sh'],
+            'agents': {'queue': queue, 'os': 'linux'}
+    }
+    run_build_step = {
+            'trigger': 'premerge-checks',
+            'label': ':rocket: build',
+            'async': False,
+            'depends_on': 'create-branch',
+            'build': {
+                    'branch': f'phab-diff-{diff_id}',
+                    'env': {'scripts_branch': '${BUILDKITE_BRANCH}'},
+            },
+    }
+    for e in os.environ:
+        if e.startswith('ph_'):
+            run_build_step['build']['env'][e] = os.getenv(e)
+    steps.append(create_branch_step)
+    steps.append(run_build_step)
+    print(yaml.dump({'steps': steps}))


### PR DESCRIPTION
Now build run on buildkite for linux with two pipelines:

- "diff checks" creates a branch, pushes it to our fork and triggers "premerge checks". Note that apply_patch2 now supports cloning repository if it does not exist yet, repository is stored outside of build folder and will be reused between builds. That works in assumption that agent will execute one step at a time.
- "premerge checks" does the actual build for existing branch. I have not figured out yet how to properly split steps and this setup is likely to fail as soon as first command fails.

Not sure if that is much better that having everything in one pipeline but it separates branch creation and might be used for different purposes too. For users we will likely point to the "build" part only.

Example https://buildkite.com/llvm-project/diff-checks/builds/75:
- took ~5m with cache which is close to what we see at Jenkins;
- triggered by a "bot" user I have added recently.