### PR TITLE
Update clang-tidy.ignore

### DIFF
--- a/scripts/clang-tidy.ignore
+++ b/scripts/clang-tidy.ignore
@@ -37,6 +37,7 @@ debuginfo-tests/dexter/feature_tests/subtools/test
 clang/test
 libclc/test
 mlir/test
+mlir/examples/standalone
 openmp/libomptarget/test
 openmp/libomptarget/deviceRTLs/nvptx/test
 openmp/runtime/test


### PR DESCRIPTION
mlir/example/standalone does not compile in the cmake environment.  It is intended to only run in a sub-cmake.