### PR TITLE
clang-tidy: Ignore all of libclc source

### DIFF
--- a/scripts/clang-tidy.ignore
+++ b/scripts/clang-tidy.ignore
@@ -35,7 +35,7 @@ compiler-rt/test/builtins/Unit/test
 debuginfo-tests/dexter/dex/tools/test
 debuginfo-tests/dexter/feature_tests/subtools/test
 clang/test
-libclc/test
+libclc
 mlir/examples/standalone
 mlir/test
 openmp/libomptarget/test


### PR DESCRIPTION
libclc implements OpenCL C, which is not actual C/C++, and implements an
external API with different naming conventions.

As clang-tidy cannot parse the source[0], just blacklist all of libclc's
sources for now.

[0]: https://buildkite.com/llvm-project/premerge-checks/builds/695