### PR TITLE
Fix exit status

### DIFF
--- a/scripts/buildkite/build_branch_pipeline.py
+++ b/scripts/buildkite/build_branch_pipeline.py
@@ -17,40 +17,62 @@ import os
 import yaml
 
 if __name__ == '__main__':
-    script_branch = os.getenv("scripts_branch", "master")
+    scripts_branch = os.getenv("scripts_branch", "master")
     queue_prefix = os.getenv("ph_queue_prefix", "")
     diff_id = os.getenv("ph_buildable_diff", "")
-
+    no_cache = os.getenv('ph_no_cache') is not None
+    filter_output = '--filter-output' if os.getenv('ph_no_filter_output') is None else ''
+    projects = os.getenv('ph_projects', 'detect')
+    log_level = os.getenv('ph_log_level', 'WARNING')
     steps = []
     linux_buld_step = {
         'label': ':linux: build and test linux',
         'key': 'linux',
         'commands': [
+            'set -euo pipefail',
+            'ccache --clear' if no_cache else '',
+             'ccache --zero-stats',
             'mkdir -p artifacts',
             'dpkg -l >> artifacts/packages.txt',
             'export SRC=${BUILDKITE_BUILD_PATH}/llvm-premerge-checks',
             'rm -rf ${SRC}',
-            'git clone --depth 1 --branch ${scripts_branch} https://github.com/google/llvm-premerge-checks.git ${SRC}',
+            f'git clone --depth 1 --branch {scripts_branch} https://github.com/google/llvm-premerge-checks.git '
+            '${SRC}',
+            'echo "llvm-premerge-checks commit"',
+            'git rev-parse HEAD',
+            'set +e',
             # Add link in review to the build.
             '${SRC}/scripts/phabtalk/add_url_artifact.py '
             '--phid="$ph_target_phid" '
             '--url="$BUILDKITE_BUILD_URL" '
             '--name="Buildkite build"',
-            '${SRC}/scripts/premerge_checks.py --check-clang-format --check-clang-tidy',
+            '${SRC}/scripts/premerge_checks.py --check-clang-format --check-clang-tidy '
+            f'--projects="{projects}" --log-level={log_level} {filter_output}',
+            'EXIT_STATUS=\\$?',
+            'echo "--- ccache stats"',
+            'ccache --show-stats',
+            'exit \\$EXIT_STATUS',
         ],
         'artifact_paths': ['artifacts/**/*', '*_result.json'],
         'agents': {'queue': f'{queue_prefix}linux'},
         'timeout_in_minutes': 120,
     }
+    clear_sccache = 'powershell -command "sccache --stop-server; ' \
+                    'Remove-Item -Recurse -Force -ErrorAction Ignore $env:SCCACHE_DIR; ' \
+                    'sccache --start-server"'
     windows_buld_step = {
         'label': ':windows: build and test windows',
         'key': 'windows',
         'commands': [
+            clear_sccache if no_cache else '',
             'sccache --zero-stats',
             'set SRC=%BUILDKITE_BUILD_PATH%/llvm-premerge-checks',
             'rm -rf %SRC%',
-            'git clone --depth 1 --branch %scripts_branch% https://github.com/google/llvm-premerge-checks.git %SRC%',
-            'powershell -command "%SRC%/scripts/premerge_checks.py; '
+            f'git clone --depth 1 --branch {scripts_branch} https://github.com/google/llvm-premerge-checks.git %SRC%',
+            'echo "llvm-premerge-checks commit"',
+            'git rev-parse HEAD',
+            'powershell -command "'
+            f'%SRC%/scripts/premerge_checks.py --projects=\'{projects}\' --log-level={log_level} {filter_output}; '
             '\\$exit=\\$?;'
             'sccache --show-stats;'
             'if (\\$exit) {'
@@ -75,7 +97,8 @@ if __name__ == '__main__':
             'buildkite-agent artifact download "*_result.json" .',
             'export SRC=${BUILDKITE_BUILD_PATH}/llvm-premerge-checks',
             'rm -rf ${SRC}',
-            'git clone --depth 1 --branch ${scripts_branch} https://github.com/google/llvm-premerge-checks.git ${SRC}',
+            f'git clone --depth 1 --branch {scripts_branch} https://github.com/google/llvm-premerge-checks.git '
+            '${SRC}',
             '${SRC}/scripts/buildkite/summary.py',
         ],
         'allow_dependency_failure': True,

--- a/scripts/exec_utils.py
+++ b/scripts/exec_utils.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# Copyright 2020 Google LLC
+#
+# Licensed under the the Apache License v2.0 with LLVM Exceptions (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import asyncio
+import logging
+import os
+from asyncio.subprocess import PIPE
+from typing import Callable, AnyStr
+
+
+async def read_stream_and_display(stream, display):
+    while True:
+        line = await stream.readline()
+        if not line:
+            break
+        display(line)  # assume it doesn't block
+
+
+async def read_and_display(write_stdout, write_stderr, *cmd, **kwargs):
+    logging.debug(f'subprocess called with {cmd}; {kwargs}')
+    process = await asyncio.create_subprocess_shell(*cmd, stdout=PIPE, stderr=PIPE, **kwargs)
+    try:
+        await asyncio.gather(
+            read_stream_and_display(process.stdout, write_stdout),
+            read_stream_and_display(process.stderr, write_stderr))
+    except Exception:
+        process.kill()
+        raise
+    finally:
+        return await process.wait()
+
+
+def tee(s: AnyStr, write1: Callable[[AnyStr], None], write2: Callable[[AnyStr], None]):
+    write1(s)
+    write2(s)
+
+
+def if_not_matches(s: AnyStr, regexp, write: Callable[[AnyStr], None]):
+    x = s
+    if isinstance(s, (bytes, bytearray)):
+        x = s.decode()
+    if regexp.match(x) is None:
+        write(s)
+
+
+def watch_shell(write_stdout, write_stderr, *cmd, **kwargs):
+    if os.name == 'nt':
+        loop = asyncio.ProactorEventLoop()  # Windows
+        asyncio.set_event_loop(loop)
+    else:
+        loop = asyncio.get_event_loop()
+    rc = loop.run_until_complete(read_and_display(write_stdout, write_stderr, *cmd, **kwargs))
+    return rc


### PR DESCRIPTION
- Fix for #207. Previously grep was exiting with 1 and fail build if all
  lines from ninja are filtered. Also piping might hide exit code of the
  initial command. Now "tee" and "grep" is implemented on python level
  and we get exit code of the original command.

- Fixed default value of "scripts_branch", print scripts commit;

- Added option to filter ninja output (on by default as before).

- Copied cache usege reporting and error handling from "master" branch
  build to diff checks (useful for debugging).