### PR TITLE
clang-tidy ignore {cuda,rocm}-runtime-wrappers.cpp

### DIFF
--- a/scripts/clang-tidy.ignore
+++ b/scripts/clang-tidy.ignore
@@ -38,6 +38,8 @@ clang/test
 libclc
 mlir/examples/standalone
 mlir/test
+mlir/tools/mlir-cuda-runner/cuda-runtime-wrappers.cpp
+mlir/tools/mlir-rocm-runner/rocm-runtime-wrappers.cpp
 openmp/libomptarget/test
 openmp/libomptarget/deviceRTLs/nvptx/test
 openmp/runtime/test


### PR DESCRIPTION
Both files include GPU header files for which clang implicitly adds include directories. However, clang-tidy does not and therefore we get compile errors (i.e. not diagnostics that we could disable with NOLINT).