### PR TITLE
add some platform-specific asan files to clang-tidy.ignore list

### DIFF
--- a/scripts/clang-tidy.ignore
+++ b/scripts/clang-tidy.ignore
@@ -32,6 +32,9 @@ llgo/test
 compiler-rt/test
 compiler-rt/test/builtins/Unit/ppc/test
 compiler-rt/test/builtins/Unit/test
+compiler-rt/lib/sanitizer_common/sanitizer_syscall_linux_.*.inc
+compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
+compiler-rt/lib/sanitizer_common/sanitizer_common_syscalls.inc
 debuginfo-tests/dexter/dex/tools/test
 debuginfo-tests/dexter/feature_tests/subtools/test
 clang/test


### PR DESCRIPTION
some compiler-rt files contain architecture-specific assembly code or
complex macroses which clang-tidy can't process properly.

In case of assembly code: we can get "unknown register name "<whatever>' in asm"
In sanitizer_common_syscalls.inc we have issuels like:
  "clang-tidy: error: unknown type name '__sanitizer_iovec'"