### PR TITLE
Add the Phabricator ID to the commit messages

### DIFF
--- a/scripts/buildkite/apply_patch.sh
+++ b/scripts/buildkite/apply_patch.sh
@@ -24,6 +24,7 @@ scripts/phabtalk/apply_patch2.py $ph_buildable_diff \
   --url $PHABRICATOR_HOST \
   --log-level $LOG_LEVEL \
   --commit $BASE_COMMIT \
+  --phid ${ph_target_phid} \
   --push-branch
 
 EXIT_STATUS=$?


### PR DESCRIPTION
This allows parsing the commit message to get the Phabricator ID when triggering jobs from unrelated pipelines.