### PR TITLE
Use buildkite API instead of passing stat via files

### DIFF
--- a/docs/playbooks.md
+++ b/docs/playbooks.md
@@ -49,7 +49,7 @@ These are the steps to set up the build server on a clean infrastructure:
     ./local_setup.sh
     ```
    If you not running docker under your user, you might need to
-   `sudo gcloud auth login --no-launch-browser && gcloud auth configure-docker`
+   `sudo gcloud auth login --no-launch-browser && sudo gcloud auth configure-docker`
    before running other commands under sudo.
 1. Delete the old cluster, if it still exists:
     ```bash

--- a/kubernetes/buildkite/linux-agents.yaml
+++ b/kubernetes/buildkite/linux-agents.yaml
@@ -66,6 +66,11 @@ spec:
                 secretKeyRef:
                   name: conduit-api-token
                   key: token
+            - name: BUILDKITE_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: buildkite-api-token-readonly
+                  key: token
       volumes:
         - name: ssd
           hostPath:

--- a/scripts/buildkite_utils.py
+++ b/scripts/buildkite_utils.py
@@ -3,6 +3,7 @@ import os
 import re
 import subprocess
 from typing import Optional
+import requests
 
 
 def upload_file(base_dir: str, file: str):
@@ -22,8 +23,22 @@ def upload_file(base_dir: str, file: str):
         return None
 
 
+class BuildkiteApi:
+    def __init__(self, token: str, organization: str):
+        self.token = token
+        self.organization = organization
+
+    def get_build(self, pipeline: str, build_number: str):
+        authorization = f'Bearer {self.token}'
+        # https://buildkite.com/docs/apis/rest-api/builds#get-a-build
+        url = f'https://api.buildkite.com/v2/organizations/{self.organization}/pipelines/{pipeline}/builds/{build_number}'
+        response = requests.get(url, headers={'Authorization': authorization})
+        if response.status_code != 200:
+            raise Exception(f'Builkite responded with non-OK status: {re.status_code}')
+        return response.json()
+
+
 def format_url(url: str, name: Optional[str] = None):
     if name is None:
         name = url
     return f"\033]1339;url='{url}';content='{name}'\a\n"
-

--- a/scripts/pipeline_premerge.py
+++ b/scripts/pipeline_premerge.py
@@ -81,9 +81,6 @@ if __name__ == '__main__':
         report_step = {
             'label': ':spiral_note_pad: report',
             'commands': [
-                'mkdir -p artifacts',
-                'buildkite-agent artifact download "*_result.json" .',
-
                 # Clone scripts.
                 'export SRC=${BUILDKITE_BUILD_PATH}/llvm-premerge-checks',
                 'rm -rf ${SRC}',
@@ -94,6 +91,7 @@ if __name__ == '__main__':
                 'echo "llvm-premerge-checks commit"',
                 'git rev-parse HEAD',
                 'cd "$BUILDKITE_BUILD_CHECKOUT_PATH"',
+
                 '${SRC}/scripts/summary.py',
             ],
             'artifact_paths': ['artifacts/**/*'],


### PR DESCRIPTION
Previous approach had drawbacks:

- every step had to implement exporting of results in fixed format

- if step failed then failure will not be detected

Now report step will fetch results directly from Buildkite.
Agents have to be updated to have BUILDKITE_API_TOKEN env.