### PR TITLE
Make clang-tidy ignore debuginfo-tests

### DIFF
--- a/scripts/clang-tidy.ignore
+++ b/scripts/clang-tidy.ignore
@@ -1,4 +1,5 @@
 # Files to be ignored by clang-tidy. Will not appear in short report and inline comments.
+debuginfo-tests/
 libcxxabi/test
 libcxxabi/test/libcxxabi/test
 libcxx/test


### PR DESCRIPTION
The only C/C++ source in this directory is for test cases. Example CL: https://reviews.llvm.org/D97668