### PR TITLE
Exclude MLIR bindings from clang-tidy checks

### DIFF
--- a/scripts/clang-tidy.ignore
+++ b/scripts/clang-tidy.ignore
@@ -41,6 +41,9 @@ debuginfo-tests/dexter/feature_tests/subtools/test
 clang/test
 libclc
 mlir/examples/standalone
+mlir/include/mlir-c/Bindings
+mlir/include/mlir/Bindings
+mlir/lib/Bindings
 mlir/test
 mlir/tools/mlir-cuda-runner
 mlir/tools/mlir-rocm-runner


### PR DESCRIPTION
Those bindings requires extra dependencies (like Python, pybind11) and clang-tidy fails to analyze the source files if they are not configured properly.