### PR TITLE
Exclude HIP headers from clang-tidy check

### DIFF
--- a/scripts/clang-tidy.ignore
+++ b/scripts/clang-tidy.ignore
@@ -38,6 +38,7 @@ compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
 compiler-rt/lib/sanitizer_common/sanitizer_common_syscalls.inc
 debuginfo-tests/dexter/dex/tools/test
 debuginfo-tests/dexter/feature_tests/subtools/test
+clang/lib/Headers/__clang_hip_*.h
 clang/test
 libclc
 mlir/examples/standalone


### PR DESCRIPTION
These HIP headers need to be checked as HIP language, currently clang-tidy cannot do that. It caused spurious warnings at https://reviews.llvm.org/D98143