### PR TITLE
windows: Install a specific version of ActivePerl

### DIFF
--- a/containers/agent-windows-vs2019/Dockerfile
+++ b/containers/agent-windows-vs2019/Dockerfile
@@ -40,7 +40,8 @@ RUN powershell -NoProfile -InputFormat None -Command `
 
 # install tools as described in https://llvm.org/docs/GettingStartedVS.html
 # and a few more that were not documented...
-RUN choco install -y ninja git python3 gnuwin activeperl
+RUN choco install -y ninja git python3 gnuwin
+RUN choco install -y activeperl --version 5.28.0.20210106
 RUN choco install -y cmake --version 3.15.4
 RUN choco install -y sccache
 RUN pip install psutil


### PR DESCRIPTION
The current default version in Chocolatey (5.28) fails to install,
with the following error:

    ERROR: The response content cannot be parsed because the Internet
    Explorer engine is not available, or Internet Explorer's first-launch
    configuration is not complete. Specify the UseBasicParsing parameter
    and try again.

This is fixed in a newer version of packaging of ActivePerl, thus request
this particular version.