### PR TITLE
windows: Install LLVM/Clang in the docker image

### DIFF
--- a/containers/agent-windows-vs2019/Dockerfile
+++ b/containers/agent-windows-vs2019/Dockerfile
@@ -42,7 +42,8 @@ RUN powershell -NoProfile -InputFormat None -Command `
 # and a few more that were not documented...
 RUN choco install -y ninja git python3 gnuwin activeperl
 RUN choco install -y cmake --version 3.15.4
-RUN choco install -y sccache
+# libcxx requires clang(-cl) to be available
+RUN choco install -y sccache llvm
 RUN pip install psutil
 
 # install python dependencies for the scripts


### PR DESCRIPTION
The main LLVM build runs fine with MSVC itself, but building libcxx isn't supported with cl.exe, only with clang-cl.

This shouldn't matter for the main LLVM build, as it still is configured to use CXX=cl (and even then, CMake defaults to cl if nothing is specified).


This, on its own, should be enough for making it possible to build libcxx in the resulting container. However, it would be more ideal for the libcxx setup if bash was available too. This can be done by adding `C:\Program Files\Git\usr\bin` to the path - however that currently breaks the main LLVM tests. With https://reviews.llvm.org/D98858 merged, it should be possible to add that directory to the path, and it would also be possible to entirely ditch GnuWin from the container. (Installing GnuWin takes a disproportionate amount of time while building the docker image, too.)

So if https://reviews.llvm.org/D98858 gets merged soon, we could include a few more changes on the Dockerfile before rebuilding an image and updating the runners. I presume that the premerge testing currently only runs on the main branch, not on older release branches (or other branches without that patch, after it has landed)?