### PR TITLE
windows: Add Git Bash to the path

### DIFF
--- a/containers/agent-windows-vs2019/Dockerfile
+++ b/containers/agent-windows-vs2019/Dockerfile
@@ -53,7 +53,7 @@ ENV PYTHONIOENCODING=UTF-8
 
 # update the path variable    
 RUN powershell -NoProfile -InputFormat None  -Command `
-    $path = $env:path + ';c:\Program Files (x86)\GnuWin32\bin;C:\Program Files\CMake\bin'; `
+    $path = $env:path + ';C:\Program Files\CMake\bin'; `
     Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\' -Name Path -Value $path
 
 # use this folder to store the worksapce'

--- a/containers/agent-windows-vs2019/Dockerfile
+++ b/containers/agent-windows-vs2019/Dockerfile
@@ -52,8 +52,9 @@ RUN pip install -r https://raw.githubusercontent.com/google/llvm-premerge-checks
 ENV PYTHONIOENCODING=UTF-8
 
 # update the path variable    
+# C:\Program Files\Git\usr\bin contains a usable bash and other unix tools.
 RUN powershell -NoProfile -InputFormat None  -Command `
-    $path = $env:path + ';C:\Program Files\CMake\bin'; `
+    $path = $env:path + ';C:\Program Files\CMake\bin;C:\Program Files\Git\usr\bin'; `
     Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\' -Name Path -Value $path
 
 # use this folder to store the worksapce'


### PR DESCRIPTION
The libcxx tests currently require bash to be available (although that might change), and the bash provided with Git is enough for fulfilling this need. (Bash can also be useful for running other scripts in the libcxx CI chain outside of the tests themselves.)

For the main LLVM testing, this works once https://reviews.llvm.org/D98858 is merged.

This also allows getting rid of GnuWin altogether.
