### PR TITLE
windows: Stop installing GnuWin

### DIFF
--- a/containers/agent-windows-vs2019/Dockerfile
+++ b/containers/agent-windows-vs2019/Dockerfile
@@ -40,7 +40,7 @@ RUN powershell -NoProfile -InputFormat None -Command `
 
 # install tools as described in https://llvm.org/docs/GettingStartedVS.html
 # and a few more that were not documented...
-RUN choco install -y ninja git python3 gnuwin
+RUN choco install -y ninja git python3
 RUN choco install -y activeperl --version 5.28.0.20210106
 RUN choco install -y cmake --version 3.15.4
 # libcxx requires clang(-cl) to be available


### PR DESCRIPTION
These tools aren't actually needed; the same tools from Git from Windows fill the same need.

This change isn't strictly needed, but it speeds up building the docker image a bit.