### PR TITLE
Remove GnuWin, add Git Bash to the path

### DIFF
--- a/containers/agent-windows-vs2019/Dockerfile
+++ b/containers/agent-windows-vs2019/Dockerfile
@@ -40,7 +40,6 @@ RUN powershell -NoProfile -InputFormat None -Command `
 
 # install tools as described in https://llvm.org/docs/GettingStartedVS.html
 # and a few more that were not documented...
-RUN choco install -y gnuwin
 RUN choco install -y ninja git python3
 RUN choco install -y activeperl --version 5.28.0.20210106
 RUN choco install -y cmake --version 3.15.4
@@ -57,7 +56,7 @@ ENV PYTHONIOENCODING=UTF-8
 # update the path variable    
 # C:\Program Files\Git\usr\bin contains a usable bash and other unix tools.
 RUN powershell -NoProfile -InputFormat None  -Command `
-    $path = $env:path + ';C:\Program Files\CMake\bin;c:\Program Files (x86)\GnuWin32\bin'; `
+    $path = $env:path + ';C:\Program Files\CMake\bin;C:\Program Files\Git\usr\bin'; `
     Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\' -Name Path -Value $path
 
 # use this folder to store the worksapce'


### PR DESCRIPTION
Both the main and the release/12.x branches of llvm-project should
work when built in a Windows Container with Git Bash in path now.