### PR TITLE
Install an older version of ActivePerl

### DIFF
--- a/containers/agent-windows-vs2019/Dockerfile
+++ b/containers/agent-windows-vs2019/Dockerfile
@@ -42,7 +42,7 @@ RUN powershell -NoProfile -InputFormat None -Command `
 # and a few more that were not documented...
 RUN choco install -y gnuwin
 RUN choco install -y ninja git python3
-RUN choco install -y activeperl --version 5.28.0.20210106
+RUN choco install -y activeperl --version 5.24.3.2404001
 RUN choco install -y cmake --version 3.15.4
 # libcxx requires clang(-cl) to be available
 RUN choco install -y sccache llvm


### PR DESCRIPTION
The current default version in Chocolatey, 5.28, fails to install.
This was previously worked around by pinning a newer upcoming
version, 5.28.0.20210106. However this version never got approved
into Chocolatey (for unknown reasons), so it's no longer available.
Therefore instead request the previous older version, 5.24.3.2404001,
which installs correctly.