### PR TITLE
Switch Bazel premerge checks to use llvm-bazel-premerge queue

### DIFF
--- a/scripts/steps.py
+++ b/scripts/steps.py
@@ -88,7 +88,7 @@ def bazel(modified_files: Set[str]) -> List:
             logging.info('bazel build is skipped as "bazel_build" is not listed in user projects and no files in '
                          'utils/bazel/ are modified')
             return []
-    agents = {'queue': 'llvm-bazel'}
+    agents = {'queue': 'llvm-bazel-premerge'}
     t = os.getenv('ph_bazel_agents')
     if t is not None:
         agents = json.loads(t)


### PR DESCRIPTION
I created a new queue for the pre-merge checks so that they won't
compete for resources with the post-merge build already running.
Obviously that creates some inefficiency, but is a simple way to make
sure neither build gets starved (in particular, we know that the current
setup of 4 agents running on a single 32-core VM is enough to handle the
commit traffic on the main branch whereas pre-merge testing volume is
likely to be more unpredictable.