### PR TITLE
Update clang-tidy.ignore

### DIFF
--- a/scripts/clang-tidy.ignore
+++ b/scripts/clang-tidy.ignore
@@ -33,7 +33,7 @@ llgo/test
 compiler-rt/test
 compiler-rt/test/builtins/Unit/ppc/test
 compiler-rt/test/builtins/Unit/test
-compiler-rt/lib/sanitizer_common/sanitizer_syscall_linux_.*.inc
+compiler-rt/lib/sanitizer_common/sanitizer.*.inc
 compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
 compiler-rt/lib/sanitizer_common/sanitizer_common_syscalls.inc
 debuginfo-tests/dexter/dex/tools/test


### PR DESCRIPTION
Extend the wildcard to match more .inc files in sanitizer_common.