### PR TITLE
Remove `llgo` from the list of projects

### DIFF
--- a/scripts/llvm-dependencies.yaml
+++ b/scripts/llvm-dependencies.yaml
@@ -32,9 +32,6 @@ dependencies:
   lldb: 
     - clang
     - llvm
-  llgo: 
-    - llvm
-    - clang
   mlir: 
     - llvm
   openmp:
@@ -73,7 +70,6 @@ allprojects:
 excludedProjects:
   windows:
     - lldb
-    - llgo
     - libunwind
     - libcxx  # no windows support
     - libcxxabi  # no windows support


### PR DESCRIPTION
It has been deleted from the LLVM repo a while ago:
https://github.com/llvm/llvm-project/commit/372bfc65deb859219270e8d467ee2918fb939599