### PR TITLE
Change the premerge checks to only check the affected projects

### DIFF
--- a/scripts/llvm-dependencies.yaml
+++ b/scripts/llvm-dependencies.yaml
@@ -32,9 +32,6 @@ dependencies:
   lldb: 
     - clang
     - llvm
-  llgo: 
-    - llvm
-    - clang
   mlir: 
     - llvm
   openmp:
@@ -73,7 +70,6 @@ allprojects:
 excludedProjects:
   windows:
     - lldb
-    - llgo
     - libunwind
     - libcxx  # no windows support
     - libcxxabi  # no windows support

--- a/scripts/llvm-dependencies.yaml
+++ b/scripts/llvm-dependencies.yaml
@@ -46,25 +46,27 @@ dependencies:
 
 # List of all projects in the LLVM monorepository. This list is taken from
 # llvm/CMakeLists.txt in "set(LLVM_ALL_PROJECTS ..."
+# The value for all project is the list of targets to tests when this project
+# is affected by a patch.
 allprojects:
-  - clang
-  - clang-tools-extra
-  - compiler-rt
-  - cross-project-tests
-  - flang
-  - libc
-  - libclc
-  - libcxx
-  - libcxxabi
-  - libunwind
-  - lld
-  - lldb
-  - mlir
-  - openmp
-  - parallel-libs
-  - polly
-  - pstl
-  - llvm
+  clang: ["check-clang"]
+  clang-tools-extra: ["check-clang-tools"]
+  compiler-rt: ["check-all"]  # check-compiler-rt seems to exist only in standalone builds.
+  cross-project-tests: ["check-cross-project"]
+  flang: ["check-flang"]
+  libc: ["check-libc"]
+  libclc: ["check-all"] # There does not seem to be a more specific target.
+  libcxx: ["check-cxx"]
+  libcxxabi: ["check-cxxabi"]
+  libunwind: ["check-unwind"]
+  lld: ["check-lld"]
+  lldb: ["check-all"] # FIXME: `check-lldb` may not include every lldb tests?
+  mlir: ["check-mlir"]
+  openmp: ["check-all"] # There does not seem to be a more specific target.
+  parallel-libs: ["check-all"]
+  polly: ["check-polly-tests"]
+  pstl: ["check-all"] # There does not seem to be a more specific target.
+  llvm: ["check-llvm"]
 
 # projects excluded from automatic configuration as they could not be built
 excludedProjects:


### PR DESCRIPTION
The current setup is configuring the "affected projects" as well
as their dependencies, and run `ninja all` followed by
`ninja check-all`.

This is quite a pessimization for leaf project which don't need to
build and run the tests for their dependencies.
For example a patch affecting only MLIR shouldn't need to build
and run LLVM and clang tests.
This patch changes this by running checks only for the affected
project. For example a patch touching `mlir` is affecting `mlir`
and `flang`. However `flang` depends on `clang`. So the list of
projects to configure is `mlir;flang;clang;llvm;`, but we want
to test only mlir and flang ; we'll run only `ninja check-mlir
check-flang`.

In practice in this example running `ninja all` builds 5658 targets
and `ninja check-all` after that adds 716 more targets. On the other
hands `ninja check-flang check-mlir` results in 3997 targets total.

Concretely the contract with premerge_checks.py is changed so that
the expected argument for the --projects flag is only the list of
affected project, dependencies are automatically added.

