### PR TITLE
Fix building the agent-windows-vs2019 image

### DIFF
--- a/containers/agent-windows-vs2019/Dockerfile
+++ b/containers/agent-windows-vs2019/Dockerfile
@@ -40,8 +40,24 @@ RUN powershell -NoProfile -InputFormat None -Command `
 
 # install tools as described in https://llvm.org/docs/GettingStartedVS.html
 # and a few more that were not documented...
-RUN choco install -y ninja git python3
-RUN choco install -y activeperl --version 5.24.3.2404001
+RUN choco install -y ninja git
+# Pin an older version of Python; the current Python 3.10 fails when
+# doing "pip install" for the other dependencies, as it fails to find libxml
+# while compiling some package.
+RUN choco install -y python3 --version 3.9.7
+
+# ActivePerl is currently not installable via Chocolatey, see
+# http://disq.us/p/2ipditb. Install StrawberryPerl instead. Unfortunately,
+# StrawberryPerl not only installs Perl, but also a redundant C/C++ compiler
+# toolchain, and a copy of pkg-config which can cause misdetections for other
+# built products, see
+# https://github.com/StrawberryPerl/Perl-Dist-Strawberry/issues/11 for further
+# details. Remove the redundant and unnecessary parts of the StrawberryPerl
+# install.
+RUN choco install -y strawberryperl && `
+    rmdir /q /s c:\strawberry\c && `
+    del /q c:\strawberry\perl\bin\pkg-config*
+
 # libcxx requires clang(-cl) to be available
 RUN choco install -y sccache llvm
 RUN pip install psutil


### PR DESCRIPTION
The current version of Python fails to build some dependencies, but
pinning the previous version works.

ActivePerl is no longer installable via Chocolatey (neither current
nor older versions) as ActiveState don't provide the downloads
without registration any longer (and even if registered, only
provide the latest, continuously updated version for free users, which
can't match the package manager checksums), see http://disq.us/p/2ipditb
for further discussion.

Replace ActivePerl with StrawberryPerl. StrawberryPerl has other
drawbacks, as it installs a whole C/C++ toolchain as part of it,
and copies of pkg-config tools that can cause package misdetections.
Remove these after installing it, see
https://github.com/StrawberryPerl/Perl-Dist-Strawberry/issues/11
for discussion on the inconveniences of installing it.