### PR TITLE
Trigger git gc on windows only for ~5% of builds.

### DIFF
--- a/scripts/windows/post-checkout.ps1
+++ b/scripts/windows/post-checkout.ps1
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-echo "running git gc"
-pwd
-git gc
+# As git gc takes non-trivial time on windows, run it only 5% of the time.
+if (( Get-Random -Maximum 100 ) -lt 5 ) {
+  echo "running git gc"
+  pwd
+  git gc
+}
+


### PR DESCRIPTION
It takes almost 5 minutes on windows and we don't need to run it that
often.

Fixes #375