### PR TITLE
Adding an `emptyDir` to kubernetes deployment

### DIFF
--- a/containers/buildkite-premerge-debian/Dockerfile
+++ b/containers/buildkite-premerge-debian/Dockerfile
@@ -12,5 +12,8 @@ RUN chmod og+rx /usr/local/bin/*.sh
 COPY --chown=buildkite-agent:buildkite-agent pre-checkout /etc/buildkite-agent/hooks
 COPY --chown=buildkite-agent:buildkite-agent post-checkout /etc/buildkite-agent/hooks
 
+# buildkite working directory
+VOLUME /var/lib/buildkite-agent
+
 ENTRYPOINT ["entrypoint.sh"]
 CMD ["gosu", "buildkite-agent", "buildkite-agent", "start", "--no-color"]

--- a/kubernetes/buildkite/linux-agents.yaml
+++ b/kubernetes/buildkite/linux-agents.yaml
@@ -45,6 +45,8 @@ spec:
           volumeMounts:
             - name: github-ssh
               mountPath: /mnt/ssh
+            - name: workdir
+              mountPath: /var/lib/buildkite-agent
           env:
             - name: BUILDKITE_AGENT_TOKEN
               valueFrom:
@@ -73,6 +75,8 @@ spec:
         - name: github-ssh
           secret:
             secretName: github-ssh
+        - name: workdir
+          emptyDir: {}
       nodeSelector:
         cloud.google.com/gke-nodepool: linux-agents-2
       terminationGracePeriodSeconds: 3600


### PR DESCRIPTION
This should resolve the out-of-disk problems reported in #379

Mounting an [emptyDir volume](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) for the Buildkite working directory should remove the disk space limitations from Kubernetes. So now it's only limited by the physical disc space available to the VM.

I did not check in detail but it looks like the ccache folder is also below `/var/lib/buildkite-agent` so that should be covered as well.

It might cause issues with the permissions. In that case we would probably need to change the permissions after the volume is mounted. So that would have to go into the `entrypoint.sh` script.

@metaflow Can you please review the change? I did not dare to apply it so far...