### PR TITLE
Revert status note about pre-merge checks being disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Status
 
-Premerge checks are disabled due a high number of false positives.
+No known issues :see_no_evil:
 
 # Overview
 


### PR DESCRIPTION
These appear to be enabled and functioning fine. I see builds running
right now.