### PR TITLE
Update to the latest release of llvm-mingw (based on LLVM 14.0.0)

### DIFF
--- a/containers/agent-windows-vs2019/Dockerfile
+++ b/containers/agent-windows-vs2019/Dockerfile
@@ -65,10 +65,10 @@ RUN pip install psutil
 # install python dependencies for the scripts
 RUN pip install -r https://raw.githubusercontent.com/google/llvm-premerge-checks/main/scripts/requirements.txt
 
-RUN curl -LO https://github.com/mstorsjo/llvm-mingw/releases/download/20211002/llvm-mingw-20211002-ucrt-x86_64.zip && `
+RUN curl -LO https://github.com/mstorsjo/llvm-mingw/releases/download/20220323/llvm-mingw-20220323-ucrt-x86_64.zip && `
     powershell Expand-Archive llvm-mingw-*-ucrt-x86_64.zip -DestinationPath . && `
     del llvm-mingw-*-ucrt-x86_64.zip && `
-    ren llvm-mingw-20211002-ucrt-x86_64 llvm-mingw
+    ren llvm-mingw-20220323-ucrt-x86_64 llvm-mingw
 
 # configure Python encoding
 ENV PYTHONIOENCODING=UTF-8


### PR DESCRIPTION
(The chocolatey package of LLVM has been updated to 14.0.0 now too, so rebuilding the docker image should pick that up too, if it gets rebuilt from scratch.)