### PR TITLE
[Bazel] Explicitly build with `-Werror`

### DIFF
--- a/scripts/steps.py
+++ b/scripts/steps.py
@@ -100,7 +100,7 @@ def bazel(modified_files: Set[str], force: bool = False) -> List:
         'commands': [
             'set -eu',
             'cd utils/bazel',
-            'bazel query //... + @llvm-project//... | xargs bazel test --config=generic_clang --config=rbe --test_output=errors --test_tag_filters=-nobuildkite --build_tag_filters=-nobuildkite',
+            'bazel query //... + @llvm-project//... | xargs bazel test --config=generic_clang --config=rbe --copt=-Werror --host_copt=-Werror --test_output=errors --test_tag_filters=-nobuildkite --build_tag_filters=-nobuildkite',
         ],
         'agents': agents,
         'timeout_in_minutes': 120,


### PR DESCRIPTION
In https://reviews.llvm.org/D123481 we're removing this from the
default builds, but we still want it in CI builds where we know the
platform and compiler configuration.