### PR TITLE
Use --config=ci instead of rbe

### DIFF
--- a/containers/base-debian/Dockerfile
+++ b/containers/base-debian/Dockerfile
@@ -27,7 +27,7 @@ RUN echo 'install llvm 13'; \
     chmod +x llvm.sh; \
     ./llvm.sh 13;\
     apt-get update; \
-    apt install -y clang-format-13 clang-tidy-13 lld-13;
+    apt install -y clang-format-13 clang-tidy-13;
 
 RUN echo 'configure locale'; \
     sed --in-place '/en_US.UTF-8/s/^#//' /etc/locale.gen ;\

--- a/containers/base-debian/Dockerfile
+++ b/containers/base-debian/Dockerfile
@@ -27,7 +27,7 @@ RUN echo 'install llvm 13'; \
     chmod +x llvm.sh; \
     ./llvm.sh 13;\
     apt-get update; \
-    apt install -y clang-format-13 clang-tidy-13;
+    apt install -y clang-format-13 clang-tidy-13 lld-13;
 
 RUN echo 'configure locale'; \
     sed --in-place '/en_US.UTF-8/s/^#//' /etc/locale.gen ;\

--- a/containers/buildkite-premerge-debian/Dockerfile
+++ b/containers/buildkite-premerge-debian/Dockerfile
@@ -5,7 +5,7 @@ RUN echo 'install buildkite' ;\
     sh -c 'echo deb https://apt.buildkite.com/buildkite-agent stable main > /etc/apt/sources.list.d/buildkite-agent.list' ;\
     apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198 ;\
     apt-get update ;\
-    apt-get install -y buildkite-agent tini gosu; \
+    apt-get install -y buildkite-agent tini gosu lld-13 clang-13 clang-tidy-13 clang-format-13; \
     apt-get clean;
 COPY *.sh /usr/local/bin/
 RUN chmod og+rx /usr/local/bin/*.sh
@@ -17,3 +17,11 @@ VOLUME /var/lib/buildkite-agent
 
 ENTRYPOINT ["entrypoint.sh"]
 CMD ["gosu", "buildkite-agent", "buildkite-agent", "start", "--no-color"]
+
+RUN ln -s /usr/bin/clang-13 /usr/bin/clang;\
+    ln -s /usr/bin/clang++-13 /usr/bin/clang++;\
+    ln -s /usr/bin/clang-tidy-13 /usr/bin/clang-tidy;\
+    ln -s /usr/bin/clang-tidy-diff-13.py /usr/bin/clang-tidy-diff;\
+    ln -s /usr/bin/clang-format-13 /usr/bin/clang-format;\
+    ln -s /usr/bin/clang-format-diff-13 /usr/bin/clang-format-diff;\
+    ln -s /usr/bin/lld-13 /usr/bin/lld

--- a/containers/buildkite-premerge-debian/Dockerfile
+++ b/containers/buildkite-premerge-debian/Dockerfile
@@ -8,6 +8,15 @@ RUN echo 'install buildkite' ;\
     apt-get install -y buildkite-agent tini gosu lld-13 clang-13 clang-tidy-13 clang-format-13; \
     apt-get clean;
 COPY *.sh /usr/local/bin/
+
+RUN ln -s /usr/bin/clang-13 /usr/bin/clang;\
+    ln -s /usr/bin/clang++-13 /usr/bin/clang++;\
+    ln -s /usr/bin/clang-tidy-13 /usr/bin/clang-tidy;\
+    ln -s /usr/bin/clang-tidy-diff-13.py /usr/bin/clang-tidy-diff;\
+    ln -s /usr/bin/clang-format-13 /usr/bin/clang-format;\
+    ln -s /usr/bin/clang-format-diff-13 /usr/bin/clang-format-diff;\
+    ln -s /usr/bin/lld-13 /usr/bin/lld
+
 RUN chmod og+rx /usr/local/bin/*.sh
 COPY --chown=buildkite-agent:buildkite-agent pre-checkout /etc/buildkite-agent/hooks
 COPY --chown=buildkite-agent:buildkite-agent post-checkout /etc/buildkite-agent/hooks
@@ -17,11 +26,3 @@ VOLUME /var/lib/buildkite-agent
 
 ENTRYPOINT ["entrypoint.sh"]
 CMD ["gosu", "buildkite-agent", "buildkite-agent", "start", "--no-color"]
-
-RUN ln -s /usr/bin/clang-13 /usr/bin/clang;\
-    ln -s /usr/bin/clang++-13 /usr/bin/clang++;\
-    ln -s /usr/bin/clang-tidy-13 /usr/bin/clang-tidy;\
-    ln -s /usr/bin/clang-tidy-diff-13.py /usr/bin/clang-tidy-diff;\
-    ln -s /usr/bin/clang-format-13 /usr/bin/clang-format;\
-    ln -s /usr/bin/clang-format-diff-13 /usr/bin/clang-format-diff;\
-    ln -s /usr/bin/lld-13 /usr/bin/lld

--- a/containers/buildkite-premerge-debian/Dockerfile
+++ b/containers/buildkite-premerge-debian/Dockerfile
@@ -5,9 +5,17 @@ RUN echo 'install buildkite' ;\
     sh -c 'echo deb https://apt.buildkite.com/buildkite-agent stable main > /etc/apt/sources.list.d/buildkite-agent.list' ;\
     apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198 ;\
     apt-get update ;\
-    apt-get install -y buildkite-agent tini gosu lld-13 clang-13 clang-tidy-13 clang-format-13; \
+    apt-get install -y buildkite-agent tini gosu; \
     apt-get clean;
 COPY *.sh /usr/local/bin/
+
+# LLVM must be installed after prerequsite packages.
+RUN echo 'install llvm 13'; \
+    wget https://apt.llvm.org/llvm.sh; \
+    chmod +x llvm.sh; \
+    ./llvm.sh 13;\
+    apt-get update; \
+    apt install -y clang-format-13 clang-tidy-13;
 
 RUN ln -s /usr/bin/clang-13 /usr/bin/clang;\
     ln -s /usr/bin/clang++-13 /usr/bin/clang++;\

--- a/scripts/steps.py
+++ b/scripts/steps.py
@@ -101,7 +101,7 @@ def bazel(modified_files: Set[str], force: bool = False) -> List:
         'commands': [
             'set -eu',
             'cd utils/bazel',
-            'bazel query //... + @llvm-project//... | xargs bazel test --config=generic_clang --config=rbe --copt=-Werror --host_copt=-Werror --test_output=errors --test_tag_filters=-nobuildkite --build_tag_filters=-nobuildkite',
+            'bazel query //... + @llvm-project//... | xargs bazel test --config=ci --remote_cache=https://storage.googleapis.com/llvm-bazel-cache --google_default_credentials=true --copt=-Werror --host_copt=-Werror',
         ],
         'agents': agents,
         'timeout_in_minutes': 120,

--- a/scripts/steps.py
+++ b/scripts/steps.py
@@ -102,10 +102,8 @@ def bazel(modified_files: Set[str], force: bool = False) -> List:
             'set -eu',
             'cd utils/bazel',
             'ls /usr/bin/',
-            'ls /usr/local/bin/',
-            '/usr/bin/lld --help',
             # TODO: remove linkopt being overriden once lld is properly available
-            'bazel query //... + @llvm-project//... | xargs bazel test --config=ci --remote_cache=https://storage.googleapis.com/llvm-bazel-cache --google_default_credentials=true --copt=-Werror --host_copt=-Werror --linkopt=-fuse-ld=/usr/bin/lld --host_linkopt=-fuse-ld=/usr/bin/lld',
+            'bazel query //... + @llvm-project//... | xargs bazel test --remote_cache=https://storage.googleapis.com/llvm-bazel-cache --google_default_credentials=true --copt=-Werror --host_copt=-Werror',
         ],
         'agents': agents,
         'timeout_in_minutes': 120,

--- a/scripts/steps.py
+++ b/scripts/steps.py
@@ -101,6 +101,7 @@ def bazel(modified_files: Set[str], force: bool = False) -> List:
         'commands': [
             'set -eu',
             'cd utils/bazel',
+            'ls /usr/bin/'
             '/usr/bin/lld --help',
             # TODO: remove linkopt being overriden once lld is properly available
             'bazel query //... + @llvm-project//... | xargs bazel test --config=ci --remote_cache=https://storage.googleapis.com/llvm-bazel-cache --google_default_credentials=true --copt=-Werror --host_copt=-Werror --linkopt=-fuse-ld=/usr/bin/lld --host_linkopt=-fuse-ld=/usr/bin/lld',

--- a/scripts/steps.py
+++ b/scripts/steps.py
@@ -102,7 +102,7 @@ def bazel(modified_files: Set[str], force: bool = False) -> List:
             'set -eu',
             'cd utils/bazel',
             # TODO: remove linkopt being overriden once lld is properly available
-            'bazel query //... + @llvm-project//... | xargs bazel test --config=ci --remote_cache=https://storage.googleapis.com/llvm-bazel-cache --google_default_credentials=true --copt=-Werror --host_copt=-Werror --linkopt="" --host_linkopt=""',
+            'bazel query //... + @llvm-project//... | xargs bazel test --config=ci --remote_cache=https://storage.googleapis.com/llvm-bazel-cache --google_default_credentials=true --copt=-Werror --host_copt=-Werror --linkopt=-fuse-ld=ld --host_linkopt=-fuse-ld=ld',
         ],
         'agents': agents,
         'timeout_in_minutes': 120,

--- a/scripts/steps.py
+++ b/scripts/steps.py
@@ -101,7 +101,7 @@ def bazel(modified_files: Set[str], force: bool = False) -> List:
         'commands': [
             'set -eu',
             'cd utils/bazel',
-            'ls /usr/bin/'
+            'ls /usr/bin/',
             '/usr/bin/lld --help',
             # TODO: remove linkopt being overriden once lld is properly available
             'bazel query //... + @llvm-project//... | xargs bazel test --config=ci --remote_cache=https://storage.googleapis.com/llvm-bazel-cache --google_default_credentials=true --copt=-Werror --host_copt=-Werror --linkopt=-fuse-ld=/usr/bin/lld --host_linkopt=-fuse-ld=/usr/bin/lld',

--- a/scripts/steps.py
+++ b/scripts/steps.py
@@ -101,8 +101,10 @@ def bazel(modified_files: Set[str], force: bool = False) -> List:
         'commands': [
             'set -eu',
             'cd utils/bazel',
+            'which lld',
+            'lld --help',
             # TODO: remove linkopt being overriden once lld is properly available
-            'bazel query //... + @llvm-project//... | xargs bazel test --config=ci --remote_cache=https://storage.googleapis.com/llvm-bazel-cache --google_default_credentials=true --copt=-Werror --host_copt=-Werror --linkopt=-fuse-ld=ld --host_linkopt=-fuse-ld=ld',
+            'bazel query //... + @llvm-project//... | xargs bazel test --config=ci --remote_cache=https://storage.googleapis.com/llvm-bazel-cache --google_default_credentials=true --copt=-Werror --host_copt=-Werror --linkopt=-fuse-ld=/usr/bin/lld --host_linkopt=-fuse-ld=/usr/bin/lld',
         ],
         'agents': agents,
         'timeout_in_minutes': 120,

--- a/scripts/steps.py
+++ b/scripts/steps.py
@@ -102,6 +102,7 @@ def bazel(modified_files: Set[str], force: bool = False) -> List:
             'set -eu',
             'cd utils/bazel',
             'ls /usr/bin/',
+            'ls /usr/local/bin/',
             '/usr/bin/lld --help',
             # TODO: remove linkopt being overriden once lld is properly available
             'bazel query //... + @llvm-project//... | xargs bazel test --config=ci --remote_cache=https://storage.googleapis.com/llvm-bazel-cache --google_default_credentials=true --copt=-Werror --host_copt=-Werror --linkopt=-fuse-ld=/usr/bin/lld --host_linkopt=-fuse-ld=/usr/bin/lld',

--- a/scripts/steps.py
+++ b/scripts/steps.py
@@ -101,7 +101,8 @@ def bazel(modified_files: Set[str], force: bool = False) -> List:
         'commands': [
             'set -eu',
             'cd utils/bazel',
-            'bazel query //... + @llvm-project//... | xargs bazel test --config=ci --remote_cache=https://storage.googleapis.com/llvm-bazel-cache --google_default_credentials=true --copt=-Werror --host_copt=-Werror',
+            # TODO: remove linkopt being overriden once lld is properly available
+            'bazel query //... + @llvm-project//... | xargs bazel test --config=ci --remote_cache=https://storage.googleapis.com/llvm-bazel-cache --google_default_credentials=true --copt=-Werror --host_copt=-Werror --linkopt="" --host_linkopt=""',
         ],
         'agents': agents,
         'timeout_in_minutes': 120,

--- a/scripts/steps.py
+++ b/scripts/steps.py
@@ -101,8 +101,7 @@ def bazel(modified_files: Set[str], force: bool = False) -> List:
         'commands': [
             'set -eu',
             'cd utils/bazel',
-            'which lld',
-            'lld --help',
+            '/usr/bin/lld --help',
             # TODO: remove linkopt being overriden once lld is properly available
             'bazel query //... + @llvm-project//... | xargs bazel test --config=ci --remote_cache=https://storage.googleapis.com/llvm-bazel-cache --google_default_credentials=true --copt=-Werror --host_copt=-Werror --linkopt=-fuse-ld=/usr/bin/lld --host_linkopt=-fuse-ld=/usr/bin/lld',
         ],


### PR DESCRIPTION
--config=ci is the new recommended form. Additional configurations are removed that are implied by ci.

Lastly, add remote_cache and google_default_credentials. This may or may not work, but this bot is already broken, so things won't get worse, and I will follow up if this does not work.