### PR TITLE
Enable compiler-rt tests on Windows

### DIFF
--- a/scripts/llvm-dependencies.yaml
+++ b/scripts/llvm-dependencies.yaml
@@ -81,8 +81,6 @@ excludedProjects:
     - openmp # TODO: check: kuhnel has trouble with the Perl installation
     - cross-project-tests # test failing
     - check-cxxabi
-    # test stuck, needs to be killed manually: instrprof-multiprocess.test
-    - compiler-rt
   linux:
     - libcxx  # has custom checks
     - libcxxabi  # has custom checks

--- a/scripts/run_cmake_config.yaml
+++ b/scripts/run_cmake_config.yaml
@@ -30,4 +30,5 @@ arguments:
     - '-D CMAKE_CXX_FLAGS=-gmlt'
     # Bolt https://github.com/google/llvm-premerge-checks/issues/364#issuecomment-1013952831.
     - '-DBOLT_CLANG_EXE=/usr/bin/clang'
-  windows: []
+  windows:
+    - '-D COMPILER_RT_BUILD_ORC=OFF' # ORC tests failing, should investigate.


### PR DESCRIPTION
Locally, disabling the fuzzer (already globally disabled) plus the ORC tests makes everything else pass.

This may need to be reverted if some tests end up failing on the Windows bots or are flaky.